### PR TITLE
Add a test case of invalid transition with not-bang method

### DIFF
--- a/test/mechanic_machine_test.rb
+++ b/test/mechanic_machine_test.rb
@@ -36,6 +36,13 @@ class StatefulEnumTest < ActiveSupport::TestCase
   def test_invalid_transition
     bug = Bug.new
     bug.resolve!
+    assert_equal false, bug.assign
+    assert_equal 'resolved', bug.status
+  end
+
+  def test_invalid_transition!
+    bug = Bug.new
+    bug.resolve!
     assert_raises do
       bug.assign!
     end


### PR DESCRIPTION
At least it is better to check status is not changed by
invalid transition with not-bang method.
Also I think returning `false` when invalid transition is called with
not-bang method (e.g. `bug.assign`) is intended API behavior, so adding
`assert_equal false, bug.assign`.