### PR TITLE
Raise an error if trying to create not DFA

### DIFF
--- a/lib/stateful_enum/machine.rb
+++ b/lib/stateful_enum/machine.rb
@@ -68,6 +68,7 @@ module StatefulEnum
           raise "Undefined state #{to}" unless @states.include? to
           Array(from).each do |f|
             raise "Undefined state #{f}" unless @states.include? f
+            raise "Duplicate entry: Transition from #{f} to #{@transitions[f].first} has already been defined." if @transitions[f]
             @transitions[f] = [to, options[:if]]
           end
         end

--- a/test/mechanic_machine_test.rb
+++ b/test/mechanic_machine_test.rb
@@ -103,4 +103,30 @@ class StatefulEnumTest < ActiveSupport::TestCase
     tes.e
     assert 'bar', tes.col
   end
+
+  def test_duplicate_from_in_one_event
+    assert_raises do
+      Class.new(ActiveRecord::Base) do
+        enum status: {unassigned: 0, assigned: 1, resolved: 2, closed: 3} do
+          event :assign do
+            transition :unassigned => :assigned
+            transition :unassigned => :resolved
+          end
+        end
+      end
+    end
+  end
+
+  def test_not_duplicate_from_in_one_event
+    assert_nothing_raised do
+      Class.new(ActiveRecord::Base) do
+        enum status: {unassigned: 0, assigned: 1, resolved: 2, closed: 3} do
+          event :toggle do
+            transition :unassigned => :assigned
+            transition :assigned => :unassigned
+          end
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Raise an error when try to define more than one `to`s with one `from`
in one event.