### PR TITLE
Suppress warnings related Rails 5

### DIFF
--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -20,7 +20,7 @@ module Dummy
     # config.i18n.default_locale = :de
 
     # Do not swallow errors in after_commit/after_rollback callbacks.
-    config.active_record.raise_in_transactional_callbacks = true
+    config.active_record.raise_in_transactional_callbacks = true if Rails::VERSION::STRING < '5'
   end
 end
 

--- a/test/dummy/config/environments/production.rb
+++ b/test/dummy/config/environments/production.rb
@@ -22,7 +22,11 @@ Rails.application.configure do
 
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.
-  config.serve_static_files = ENV['RAILS_SERVE_STATIC_FILES'].present?
+  if Rails::VERSION::STRING >= '5'
+    config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
+  else
+    config.serve_static_files = ENV['RAILS_SERVE_STATIC_FILES'].present?
+  end
 
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = :uglifier

--- a/test/dummy/config/environments/test.rb
+++ b/test/dummy/config/environments/test.rb
@@ -13,8 +13,13 @@ Rails.application.configure do
   config.eager_load = false
 
   # Configure static file server for tests with Cache-Control for performance.
-  config.serve_static_files   = true
-  config.static_cache_control = 'public, max-age=3600'
+  if Rails::VERSION::STRING >= '5'
+    config.public_file_server.enabled = true
+    config.public_file_server.headers = { 'Cache-Control' => 'public, max-age=3600' }
+  else
+    config.serve_static_files   = true
+    config.static_cache_control = 'public, max-age=3600'
+  end
 
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true

--- a/test/dummy/db/migrate/20160307200506_create_users.rb
+++ b/test/dummy/db/migrate/20160307200506_create_users.rb
@@ -1,4 +1,4 @@
-class CreateUsers < ActiveRecord::Migration
+class CreateUsers < (Rails::VERSION::STRING >= '5' ? ActiveRecord::Migration[5.0] : ActiveRecord::Migration)
   def change
     create_table :users do |t|
       t.string :name

--- a/test/dummy/db/migrate/20160307203948_create_bugs.rb
+++ b/test/dummy/db/migrate/20160307203948_create_bugs.rb
@@ -1,4 +1,4 @@
-class CreateBugs < ActiveRecord::Migration
+class CreateBugs < (Rails::VERSION::STRING >= '5' ? ActiveRecord::Migration[5.0] : ActiveRecord::Migration)
   def change
     create_table :bugs do |t|
       t.string :title


### PR DESCRIPTION
Suppress these warnings

* DEPRECATION WARNING: `serve_static_files` is deprecated
* DEPRECATION WARNING: `static_cache_control` is deprecated
* DEPRECATION WARNING: ActiveRecord::Base.raise_in_transactional_callbacks= is deprecated
* DEPRECATION WARNING: Directly inheriting from ActiveRecord::Migration is deprecated