### PR TITLE
Use `_enum_methods_module` method instead of `@_enum_methods_module`

### DIFF
--- a/lib/stateful_enum/machine.rb
+++ b/lib/stateful_enum/machine.rb
@@ -35,7 +35,7 @@ module StatefulEnum
           if to && (!condition || instance_exec(&condition))
             #TODO transaction?
             instance_eval(&before) if before
-            ret = self.class.instance_variable_get(:@_enum_methods_module).instance_method("#{to}!").bind(self).call
+            ret = self.class.send(:_enum_methods_module).instance_method("#{to}!").bind(self).call
             instance_eval(&after) if after
             ret
           else


### PR DESCRIPTION
In Rails 4.2.6 and Rails 5.0.0.beta3, `ActiveRecord::Enum` provide
`_enum_methods_module` accessor method privately.
Sure `@_enum_methods_module` has been set by `enum` method
when we initialize `Event`, but I think it is better to use
accessor method to reduce dependency for `ActiveRecord::Enum`
internal implementation.