### PR TITLE
Set prefix and suffix options for Rails 5

### DIFF
--- a/lib/stateful_enum/active_record_extension.rb
+++ b/lib/stateful_enum/active_record_extension.rb
@@ -8,12 +8,13 @@ module StatefulEnum
     #     end
     #   end
     def enum(definitions, &block)
+      prefix, suffix = definitions[:_prefix], definitions[:_suffix]
       enum = super definitions
 
       if block
         definitions.each_key do |column|
           states = enum[column]
-          StatefulEnum::Machine.new self, column, (states.is_a?(Hash) ? states.keys : states), &block
+          StatefulEnum::Machine.new self, column, (states.is_a?(Hash) ? states.keys : states), prefix, suffix, &block
         end
       end
     end


### PR DESCRIPTION
Hello,

`_prefix` and `_suffix` options are supported from Rails 5.
https://github.com/rails/rails/pull/20999

Example:

```
class Conversation < ActiveRecord::Base
  enum status: [:active, :archived], _suffix: true
  enum comments_status: [:active, :inactive], _prefix: :comments
end
```
http://edgeapi.rubyonrails.org/classes/ActiveRecord/Enum.html