### PR TITLE
Replace `assert` with `assert_equal`

### DIFF
--- a/test/mechanic_machine_test.rb
+++ b/test/mechanic_machine_test.rb
@@ -109,7 +109,7 @@ class StatefulEnumTest < ActiveSupport::TestCase
       enum(col: [:foo, :bar]) { event(:e) { transition(foo: :bar) } }
     end.new col: 'foo'
     tes.e
-    assert 'bar', tes.col
+    assert_equal 'bar', tes.col
   end
 
   def test_duplicate_from_in_one_event


### PR DESCRIPTION
`Minitest::Assertions#assert(test, msg = nil)` check if
first argument (`test`) is not falsy value, and second argument (`msg`)
is used as a custom error message.
`assert 'bar', tes.col` always passes because first arguemtn (`'bar'`) is truthy.