### PR TITLE
Use Travis' cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: ruby
 
+cache:
+  - bundler
+
 rvm:
   - 2.2.4
   - 2.3.0


### PR DESCRIPTION
> (Bundler caching is not yet enabled automatically)
> You can explicitly enable Bundler caching in your
> .travis.yml:
> ```
> language: ruby
> cache: bundler
> ```

ref: https://docs.travis-ci.com/user/caching/#Bundler