### PR TITLE
Add 'ruby-graphviz' gem to development_dependency

### DIFF
--- a/stateful_enum.gemspec
+++ b/stateful_enum.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency 'rails'
   spec.add_development_dependency 'sqlite3'
+  spec.add_development_dependency 'ruby-graphviz'
 end


### PR DESCRIPTION
When `bundle exec rake` to run tests locally, ruby-graphviz is needed.
Sure `bundle exec rake test:all` ensures the gem is installed for
all rails versions, but `bundle exec rake test` (the default task) fails
without 'ruby-graphviz'.