### PR TITLE
Remove a needless `if`

### DIFF
--- a/lib/generators/stateful_enum/graph_generator.rb
+++ b/lib/generators/stateful_enum/graph_generator.rb
@@ -15,7 +15,7 @@ module StatefulEnum
   module Graph
     def initialize(model, _column, states, prefix, suffix, &block)
       super
-      GraphDrawer.new model, states, @prefix, @suffix, &block if block
+      GraphDrawer.new model, states, @prefix, @suffix, &block
     end
 
     class GraphDrawer


### PR DESCRIPTION
`StatefulEnum::Graph` is prepended to `StatefulEnum::Machine` and
`StatefulEnum::Machine` is always initialized with block, because
`StatefulEnum::ActiveRecordEnumExtension#enum` only initializes
`Machine` when block was given.