### PR TITLE
Use `ActiveSupport::Callbacks` instead of self defined callback method

### DIFF
--- a/lib/generators/stateful_enum/graph_generator.rb
+++ b/lib/generators/stateful_enum/graph_generator.rb
@@ -47,6 +47,7 @@ module StatefulEnum
     class EventDrawer < ::StatefulEnum::Machine::Event
       def initialize(g, states, prefix, suffix, name, &block)
         @g, @states, @prefix, @suffix, @name = g, states, prefix, suffix, name
+        @before, @after = [], []
 
         instance_eval(&block) if block
       end


### PR DESCRIPTION
This commit enables us to define multi callbacks on the same hook
(e.g. `after`).
