### PR TITLE
Supporting inherited model

### DIFF
--- a/test/dummy/app/models/post.rb
+++ b/test/dummy/app/models/post.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class Post < ActiveRecord::Base
+  enum status: {drafted: 0, published: 1} do
+    event :draft do
+      transition :published => :drafted
+    end
+
+    event :publish do
+      transition :drafted => :published
+    end
+  end
+end

--- a/test/dummy/app/models/quote_post.rb
+++ b/test/dummy/app/models/quote_post.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class QuotePost < Post
+end

--- a/test/dummy/db/migrate/20160524075858_create_posts.rb
+++ b/test/dummy/db/migrate/20160524075858_create_posts.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class CreatePosts < (Rails::VERSION::STRING >= '5' ? ActiveRecord::Migration[5.0] : ActiveRecord::Migration)
+  def change
+    create_table :posts do |t|
+      t.string :title
+      t.text :body
+      t.string :type
+      t.integer :status, default: 0
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/test/mechanic_machine_test.rb
+++ b/test/mechanic_machine_test.rb
@@ -104,6 +104,16 @@ class StatefulEnumTest < ActiveSupport::TestCase
     end
   end
 
+  def test_inherited_model
+    post = Post.new
+    post.publish!
+    assert_equal 'published', post.status
+
+    quote_post = QuotePost.new
+    quote_post.publish!
+    assert_equal 'published', quote_post.status
+  end
+
   def test_enum_definition_with_array
     ActiveRecord::Migration.create_table(:array_enum_test) {|t| t.integer :col }
     tes = Class.new(ActiveRecord::Base) do


### PR DESCRIPTION
Does not work `Model#xxxxx!` method when model is inherited like STI.
`Event` can’t find original method from `self.class._enum_methods_module`.  😢 

I fixed to memorize original method before undef.

thanks