### PR TITLE
Use Travis's new container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: ruby
 
+sudo: false
+
 cache:
+  - apt
   - bundler
 
 rvm:
@@ -13,8 +16,10 @@ gemfile:
   - gemfiles/Gemfile-rails.4.2.x
   - gemfiles/Gemfile-rails.5.0.0
 
-before_install:
- - sudo apt-get install graphviz
+addons:
+  apt:
+    packages:
+      - graphviz
 
 matrix:
   allow_failures:


### PR DESCRIPTION
Using container-based infrastructure makes build faster. (20~52s -> 1-6s)
ref: https://docs.travis-ci.com/user/ci-environment/#Virtualization-environments

To use APT packages with container-based infrastructure, we can use `addons.apt.packages`.
ref: https://docs.travis-ci.com/user/installing-dependencies/#Installing-Packages-on-Container-Based-Infrastructure