### PR TITLE
Add output_path configuration to graph generator

### DIFF
--- a/lib/generators/stateful_enum/graph_generator.rb
+++ b/lib/generators/stateful_enum/graph_generator.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails/generators/named_base'
+require 'stateful_enum/config_file'
 
 module StatefulEnum
   module Generators
@@ -39,7 +40,14 @@ module StatefulEnum
           @g.get_node(final) {|n| n['shape'] = 'doublecircle' }
         end
 
-        @g.output png: "#{model.name}.png"
+        configuration = StatefulEnum::ConfigFile.load
+        filename = if configuration['output_path'].nil?
+                    "#{model.name}.png"
+                  else
+                    File.join(configuration['output_path'], "#{model.name}.png")
+                  end
+
+        @g.output png: filename
       end
 
       def event(name, &block)

--- a/lib/stateful_enum/config_file.rb
+++ b/lib/stateful_enum/config_file.rb
@@ -1,0 +1,23 @@
+module StatefulEnum
+  class ConfigFile
+    def self.load
+      new.load
+    end
+
+    def load
+      load_file(File.expand_path('.smdconfig', Dir.pwd))
+    end
+
+    def load_file(filename)
+      content = {}
+      YAML.load(File.read(filename)).each do |key, value|
+        if ['output_path'].include?(key)
+          content[key] = value
+        end
+      end
+      content
+    rescue
+      {}
+    end
+  end
+end

--- a/test/dummy/.gitignore
+++ b/test/dummy/.gitignore
@@ -1,2 +1,3 @@
+.smdconfig
 Bug.png
 /db/test.sqlite3

--- a/test/graph_test.rb
+++ b/test/graph_test.rb
@@ -5,11 +5,23 @@ require 'test_helper'
 class GraphTest < ActiveSupport::TestCase
   def test_graph
     FileUtils.rm_f Rails.root.join('Bug.png')
+    FileUtils.rm_f Rails.root.join('.smdconfig')
 
     Dir.chdir Rails.root do
       `rails g stateful_enum:graph bug`
     end
 
     assert File.exist?(Rails.root.join('Bug.png'))
+  end
+
+  def test_output_path
+    FileUtils.rm_f Rails.root.join('doc', 'Bug.png')
+    File.write(Rails.root.join('.smdconfig'), 'output_path: doc')
+
+    Dir.chdir Rails.root do
+      `rails g stateful_enum:graph bug`
+    end
+
+    assert File.exist?(Rails.root.join('doc', 'Bug.png'))
   end
 end


### PR DESCRIPTION
Generating State Machine Diagrams is very great.
I have to change the output path of the Diagram.

So, it was implemented set of `output_path` to `.smdconfig` file.