### PR TITLE
Use the PlantUML a state machine diagram

### DIFF
--- a/lib/generators/stateful_enum/plantuml_generator.rb
+++ b/lib/generators/stateful_enum/plantuml_generator.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require 'rails/generators/named_base'
+
+module StatefulEnum
+  module Generators
+    class PlantumlGenerator < ::Rails::Generators::NamedBase
+      desc 'PlantUML a state machine diagram'
+      def plantuml
+        StatefulEnum::Machine.prepend StatefulEnum::PlantUML
+        class_name.constantize
+      end
+    end
+  end
+
+  module PlantUML
+    def initialize(model, column, states, prefix, suffix, &block)
+      super
+      UmlWriter.new model, column, states, @prefix, @suffix, &block
+    end
+
+    class UmlWriter
+      def initialize(model, column, states, prefix, suffix, &block)
+        @states, @prefix, @suffix = states, prefix, suffix
+        @items = []
+
+        if (default_value = model.columns_hash[column.to_s].default)
+          default_label = model.defined_enums[column.to_s].key default_value.to_i  # SQLite returns the default value in String
+        end
+
+        instance_eval(&block)
+
+        lines = default_label ? ["[*] --> #{default_label}"] : []
+        lines.concat @items.map {|item| "#{item.from} --> #{item.to} :#{item.label}" }
+        (@items.map(&:to).uniq - @items.map(&:from).uniq).each do |final|
+          lines.push "#{final} --> [*]"
+        end
+
+        File.write(File.join((ENV['DEST_DIR'] || Dir.pwd), "#{model.name}.puml"), lines.join("\n"))
+      end
+
+      def event(name, &block)
+        EventStore.new @items, @states, @prefix, @suffix, name, &block
+      end
+    end
+
+    class EventStore < ::StatefulEnum::Machine::Event
+      def initialize(items, states, prefix, suffix, name, &block)
+        @items, @states, @prefix, @suffix, @name = items, states, prefix, suffix, name
+
+        instance_eval(&block) if block
+      end
+
+      def transition(transitions, options = {})
+        if options.blank?
+          transitions.delete :if
+          transitions.delete :unless
+        end
+
+        transitions.each_pair do |from, to|
+          Array(from).each do |f|
+            @items.push Item.new(f, to, "#{@prefix}#{@name}#{@suffix}")
+          end
+        end
+      end
+    end
+
+    class Item < Struct.new(:from, :to, :label)
+    end
+  end
+end

--- a/test/dummy/.gitignore
+++ b/test/dummy/.gitignore
@@ -1,2 +1,3 @@
 Bug.png
+Bug.puml
 /db/test.sqlite3

--- a/test/plantuml_test.rb
+++ b/test/plantuml_test.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class PlantumlTest < ActiveSupport::TestCase
+  def test_plantuml
+    FileUtils.rm_f Rails.root.join('Bug.puml')
+
+    Dir.chdir Rails.root do
+      `rails g stateful_enum:plantuml bug`
+    end
+
+    assert File.exist?(Rails.root.join('Bug.puml'))
+  end
+
+  def test_plantuml_to_a_relative_dest_dir
+    FileUtils.rm_f Rails.root.join('tmp', 'Bug.puml')
+
+    Dir.chdir Rails.root do
+      `DEST_DIR=tmp rails g stateful_enum:plantuml bug`
+    end
+
+    assert File.exist?(Rails.root.join('tmp', 'Bug.puml'))
+  end
+
+  def test_plantuml_to_an_absolute_dest_dir
+    FileUtils.rm_f Rails.root.join('doc', 'Bug.puml')
+
+    Dir.chdir Rails.root do
+      `DEST_DIR=#{Rails.root.join('doc')} rails g stateful_enum:plantuml bug`
+    end
+
+    assert File.exist?(Rails.root.join('doc', 'Bug.puml'))
+  end
+end


### PR DESCRIPTION
Drawing a state machine diagram is very good. But in chat discussion plain text is easy to edit and convenient. So I added a generator of PlantUML.

> [PlantUML](http://plantuml.com/) is a component that allows to quickly write.

### Generator command

`% rails g stateful_enum:plantuml bug` 

### Output the Bug.puml file

```
[*] --> unassigned
unassigned --> assigned :assign
unassigned --> assigned :assign_with_unless
unassigned --> resolved :resolve
assigned --> resolved :resolve
unassigned --> closed :close
assigned --> closed :close
resolved --> closed :close
closed --> [*]
```

### Drawing diagram

Can convert to the drawing  diagram with graphviz.

![image](https://cloud.githubusercontent.com/assets/471923/21503419/b862e834-cc9a-11e6-9a8f-aa4f8bd8ca28.png)

