### PR TITLE
compatibility for non-Rails apps

### DIFF
--- a/lib/stateful_enum/active_record_extension.rb
+++ b/lib/stateful_enum/active_record_extension.rb
@@ -10,7 +10,7 @@ module StatefulEnum
     #     end
     #   end
     def enum(definitions, &block)
-      prefix, suffix = definitions[:_prefix], definitions[:_suffix] if Rails::VERSION::STRING >= '5'
+      prefix, suffix = definitions[:_prefix], definitions[:_suffix] if ActiveRecord::VERSION::STRING >= '5'
       enum = super definitions
 
       if block

--- a/lib/stateful_enum/railtie.rb
+++ b/lib/stateful_enum/railtie.rb
@@ -2,10 +2,14 @@
 
 require 'stateful_enum/active_record_extension'
 
-module StatefulEnum
-  class Railtie < ::Rails::Railtie
-    ActiveSupport.on_load :active_record do
-      ::ActiveRecord::Base.extend StatefulEnum::ActiveRecordEnumExtension
+if defined?(::Rails::Railtie)
+  module StatefulEnum
+    class Railtie < ::Rails::Railtie
+      ActiveSupport.on_load :active_record do
+        ::ActiveRecord::Base.extend StatefulEnum::ActiveRecordEnumExtension
+      end
     end
   end
+elsif defined?(::ActiveRecord::Base)
+  ::ActiveRecord::Base.extend StatefulEnum::ActiveRecordEnumExtension
 end


### PR DESCRIPTION
This allows non-Rails projects using ActiveRecord to utilize stateful_enum. It checks ActiveRecord's version number instead of Rails, and only loads the Railtie if `::Rails::Railtie` is defined. This shouldn't cause any issue with existing Rails apps.