### PR TITLE
Add `InvalidTransition` exception with more helpful message.

### DIFF
--- a/lib/stateful_enum/invalid_transition.rb
+++ b/lib/stateful_enum/invalid_transition.rb
@@ -1,0 +1,11 @@
+module StatefulEnum
+  class InvalidTransition < StandardError
+    attr_reader :state
+    attr_reader :event
+
+    def initialize(state, event)
+      @state, @event = state, event
+      super("Invalid transition from state #{@state.inspect} via event #{@event.inspect}")
+    end
+  end
+end

--- a/lib/stateful_enum/machine.rb
+++ b/lib/stateful_enum/machine.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'stateful_enum/invalid_transition'
+
 module StatefulEnum
   class Machine
     attr_reader :events
@@ -66,9 +68,10 @@ module StatefulEnum
           end
 
           # def assign!()
-          detect_enum_conflict! column, "#{value_method_name}!"
-          define_method "#{value_method_name}!" do
-            send(value_method_name) || raise('Invalid transition')
+          value_method_name_bang = "#{value_method_name}!"
+          detect_enum_conflict! column, value_method_name_bang
+          define_method value_method_name_bang do
+            send(value_method_name) || raise(InvalidTransition.new(send(column), value_method_name_bang.to_sym))
           end
 
           # def can_assign?()

--- a/test/mechanic_machine_test.rb
+++ b/test/mechanic_machine_test.rb
@@ -45,10 +45,14 @@ class StatefulEnumTest < ActiveSupport::TestCase
   def test_invalid_transition!
     bug = Bug.new
     bug.resolve!
-    assert_raises do
-      bug.assign!
-    end
+    exception =
+      assert_raises(StatefulEnum::InvalidTransition) do
+        bug.assign!
+      end
     assert_equal 'resolved', bug.status
+    assert_equal 'Invalid transition from state "resolved" via event :assign!', exception.message
+    assert_equal 'resolved', exception.state
+    assert_equal :assign!, exception.event
   end
 
   def test_can_xxxx?


### PR DESCRIPTION
I thought it would be nice to see and have access to a bit more information when the transition is invalid. This changes the `RuntimeError` to a custom `StatefulEnum::InvalidTransition` exception. The error message contains the state and the event that was attempted. Those 2 pieces of information are also stored on the exception itself for easy access.

I almost took it a step further by adding what the state would have been if the event had succeeded – e.g. in the test below: `Invalid transition from "resolved" to "assigned" via event :assign!'` – but that would take significantly more work. I believe the solution to that would require storing the events in memory. I'm not even sure how useful it would be to know that information. But if you like the idea, I would be happy to continue to explore the idea.