### PR TITLE
Support ActiveRecord 5.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ gemfile:
   - gemfiles/Gemfile-rails.4.2.x
   - gemfiles/Gemfile-rails.5.0.x
   - gemfiles/Gemfile-rails.5.1.x
+  - gemfiles/Gemfile-rails.5.2.x
 
 addons:
   apt:

--- a/gemfiles/Gemfile-rails.5.2.x
+++ b/gemfiles/Gemfile-rails.5.2.x
@@ -1,0 +1,8 @@
+source 'https://rubygems.org'
+
+gem 'stateful_enum', path: '..'
+
+gem 'rails', '~> 5.2.0'
+gem 'sqlite3'
+gem 'test-unit-rails'
+gem 'ruby-graphviz'

--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -23,5 +23,6 @@ module Dummy
 
     # Do not swallow errors in after_commit/after_rollback callbacks.
     config.active_record.raise_in_transactional_callbacks = true if Rails::VERSION::STRING =~ /^4.2/
+    config.active_record.sqlite3.represent_boolean_as_integer = true if config.active_record.sqlite3.respond_to?(:represent_boolean_as_integer)
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,7 +5,14 @@ ENV["RAILS_ENV"] = "test"
 
 require File.expand_path("../../test/dummy/config/environment.rb", __FILE__)
 ActiveRecord::Migration.verbose = false
-ActiveRecord::Migrator.migrate(ActiveRecord::Migrator.migrations_paths = [File.expand_path("../../test/dummy/db/migrate", __FILE__)])
+if ActiveRecord::Migrator.respond_to? :migrate
+  ActiveRecord::Migrator.migrate(ActiveRecord::Migrator.migrations_paths = [File.expand_path("../../test/dummy/db/migrate", __FILE__)])
+else
+  ActiveRecord::Migrator.migrations_paths << File.expand_path('../dummy/db/migrate', __FILE__)
+  ActiveRecord::Tasks::DatabaseTasks.drop_current 'test'
+  ActiveRecord::Tasks::DatabaseTasks.create_current 'test'
+  ActiveRecord::Tasks::DatabaseTasks.migrate
+end
 
 require 'test/unit/rails/test_help'
 


### PR DESCRIPTION
support migrate with ActiveRecored 5.2.
ActiveRecord 5.2 removed `ActiveRecord::Migrator.migrate`.