### PR TITLE
Support STI and inheritance(with test)

### DIFF
--- a/lib/stateful_enum/machine.rb
+++ b/lib/stateful_enum/machine.rb
@@ -54,7 +54,7 @@ module StatefulEnum
             if to && (!condition || instance_exec(&condition))
               #TODO transaction?
               run_callbacks new_method_name do
-                original_method = self.class.send(:_enum_methods_module).instance_method "#{prefix}#{to}#{suffix}!"
+                original_method = self.class.base_class.send(:_enum_methods_module).instance_method "#{prefix}#{to}#{suffix}!"
                 original_method.bind(self).call
               end
             else

--- a/test/dummy/app/models/special_bug.rb
+++ b/test/dummy/app/models/special_bug.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class SpecialBug < Bug
+end

--- a/test/dummy/db/migrate/20160307203948_create_bugs.rb
+++ b/test/dummy/db/migrate/20160307203948_create_bugs.rb
@@ -8,6 +8,7 @@ class CreateBugs < (Rails::VERSION::STRING >= '5' ? ActiveRecord::Migration[5.0]
       t.integer :status, default: 0
       t.integer :assigned_to_id
       t.datetime :resolved_at
+      t.string :type
 
       t.timestamps null: false
     end

--- a/test/mechanic_machine_test.rb
+++ b/test/mechanic_machine_test.rb
@@ -11,6 +11,14 @@ class StatefulEnumTest < ActiveSupport::TestCase
     assert_equal 'assigned', bug.status
   end
 
+  def test_transition_to_sti
+    special_bug = SpecialBug.new
+    assert_equal 'unassigned', special_bug.status
+    special_bug.assigned_to = User.create!(name: 'user 1')
+    special_bug.assign
+    assert_equal 'assigned', special_bug.status
+  end
+
   def test_transition!
     bug = Bug.new
     bug.assigned_to = User.create!(name: 'user 1')


### PR DESCRIPTION
dups #29 .But I wrote test.

Original pull request description is below.

> I used the gem on a STI class and got an error which would be solved with using on self.class => self.class.base_class.
>
> It would be nice if you could do a patch release with this fix.
> 
> Thank you in advance!!

---- 

If use stateful_enum on STI model, raise that error.

```
/home/unasuke/src/github.com/unasuke/stateful_enum/test/mechanic_machine_test.rb:18:in `test_transition_to_sti'
     15:     special_bug = SpecialBug.new
     16:     assert_equal 'unassigned', special_bug.status
     17:     special_bug.assigned_to = User.create!(name: 'user 1')
  => 18:     special_bug.assign
     19:     assert_equal 'assigned', special_bug.status
     20:   end
     21:
/home/unasuke/src/github.com/unasuke/stateful_enum/lib/stateful_enum/machine.rb:56:in `block (2 levels) in initialize'
/home/unasuke/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/activesupport-5.2.0/lib/active_support/callbacks.rb:98:in `run_callbacks'
/home/unasuke/src/github.com/unasuke/stateful_enum/lib/stateful_enum/machine.rb:57:in `block (3 levels) in initialize'
/home/unasuke/src/github.com/unasuke/stateful_enum/lib/stateful_enum/machine.rb:57:in `instance_method'
Error: test_transition_to_sti(StatefulEnumTest): NameError: undefined method `assigned!' for module `#<Module:0x0000564443546130>'
=========================================================================================================
```