### PR TITLE
dynamically define an update validator

### DIFF
--- a/lib/stateful_enum/machine.rb
+++ b/lib/stateful_enum/machine.rb
@@ -57,7 +57,7 @@ module StatefulEnum
             if to && (condition.nil? || instance_exec(&condition))
               #TODO transaction?
               run_callbacks value_method_name do
-                original_method = self.class.send(:_enum_methods_module).instance_method "#{prefix}#{to}#{suffix}!"
+                original_method = self.base_class.send(:_enum_methods_module).instance_method "#{prefix}#{to}#{suffix}!"
                 original_method.bind(self).call
               end
             else

--- a/test/dummy/app/models/special_bug.rb
+++ b/test/dummy/app/models/special_bug.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class SpecialBug < Bug
+end

--- a/test/dummy/db/migrate/20160307203948_create_bugs.rb
+++ b/test/dummy/db/migrate/20160307203948_create_bugs.rb
@@ -8,6 +8,7 @@ class CreateBugs < (Rails::VERSION::MAJOR >= 5 ? ActiveRecord::Migration[5.0] : 
       t.integer :status, default: 0
       t.integer :assigned_to_id
       t.datetime :resolved_at
+      t.string :type
 
       t.timestamps null: false
     end

--- a/test/mechanic_machine_test.rb
+++ b/test/mechanic_machine_test.rb
@@ -10,6 +10,14 @@ class StatefulEnumTest < ActiveSupport::TestCase
     bug.assign
     assert_equal 'assigned', bug.status
   end
+  
+  def test_transition_to_sti
+    special_bug = SpecialBug.new
+    assert_equal 'unassigned', special_bug.status
+    special_bug.assigned_to = User.create!(name: 'user 1')
+    special_bug.assign
+    assert_equal 'assigned', special_bug.status
+  end
 
   def test_transition!
     bug = Bug.new


### PR DESCRIPTION
This adds a commit from [here](https://github.com/amatsuda/stateful_enum/commit/535bf2fb9679ee5b9c7c72db11f809a57c4303f0) that never found its way into the master branch.

Some minor changes to make tests pass and make the code slightly more understandable.